### PR TITLE
Fix issues with Continuous Integration on Forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 go: 
  - tip
 
+go_import_path: github.com/loklak/loklak_api_go
+
 install:
  - go get github.com/hokaccha/go-prettyjson
 


### PR DESCRIPTION
Because for a new fork that'll be a Pull Request to the upstream
project. It's a good idea to have this intact so Travis will always
install it on 'github.com/loklak/loklak_api_go'.
