### PR TITLE
Use test instead of install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,9 @@ go:
 install:
  - go get github.com/hokaccha/go-prettyjson
 
+matrix:
+  allow_failures:
+  - go: tip
+
 script:
- - go install
+ - go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ matrix:
   - go: tip
 
 script:
- - go test
+  - go install
+  - go test


### PR DESCRIPTION
Install is redundant at this point, because Travis installs them to the
actual directory.

It's preferable to use test instead of install because it runs Unit
tests like the examples.

For this, failures are allowed because the code is actually dead and
won't work at all.
