### PR TITLE
Replace http://loklak.org with a Loklak Server

### DIFF
--- a/loklak_api_go.go
+++ b/loklak_api_go.go
@@ -1,4 +1,4 @@
-// Package loklak_api_go is a library for interacting with http://loklak.org/
+// Package loklak_api_go is a library for interacting with a Loklak server
 package loklak_api_go
 
 import (


### PR DESCRIPTION
It's better to use 'a Loklak Server' because it implies that It can be
used on any Loklak server instances. If it's 'loklak.org', It means It
can only interact with loklak.org and not other instances of Loklak
Server
